### PR TITLE
Support Windows ARM64 using MSVC

### DIFF
--- a/.github/workflows/build-luau.windows.yml
+++ b/.github/workflows/build-luau.windows.yml
@@ -4,16 +4,20 @@ on:
   workflow_call:
   workflow_dispatch:
 
-
 jobs:
   build:
     name: Build ${{ matrix.target }} on Windows
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
     continue-on-error: true
     strategy:
       matrix:
         include:
-          - target: x86_64-pc-windows-gnu
+          - target: x86_64-pc-windows-msvc
+            arch: x64
+            runs-on: windows-latest
+          - target: aarch64-pc-windows-msvc
+            arch: arm64
+            runs-on: windows-11-arm
 
     steps:
       - name: Checkout repository
@@ -26,12 +30,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Set up MinGW
-        id: mingw_setup
-        uses: egor-tensin/setup-mingw@v2
+      - name: Set up MSVC
+        uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
-          platform: x64
-          version: 12.2.0
+          arch: ${{ matrix.arch }}
 
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v1
@@ -40,10 +42,19 @@ jobs:
         working-directory: native/luau-ffi
         env:
           CARGO_BUILD_TARGET: ${{ matrix.target }}
-          CC: ${{ steps.mingw_setup.outputs.gcc }}
-          CXX: ${{ steps.mingw_setup.outputs.gxx }}
         run: |
           cargo build --release --target ${{ matrix.target }}
+
+      - name: Rename build outputs
+        shell: pwsh
+        run: |
+          $dir = "native/luau-ffi/target/${{ matrix.target }}/release"
+          if (Test-Path "$dir/luau.dll") { Rename-Item "$dir/luau.dll" -NewName "libluau.dll" -Force }
+          if (Test-Path "$dir/luau.pdb") { Rename-Item "$dir/luau.pdb" -NewName "libluau.pdb" -Force }
+          if (Test-Path "$dir/luau.lib") { Rename-Item "$dir/luau.lib" -NewName "libluau.lib" -Force }
+          if (Test-Path "$dir/luau.dll.lib") { Rename-Item "$dir/luau.dll.lib" -NewName "libluau.dll.lib" -Force }
+          if (Test-Path "$dir/luau.dll.exp") { Rename-Item "$dir/luau.dll.exp" -NewName "libluau.dll.exp" -Force }
+          if (Test-Path "$dir/luau.d") { Rename-Item "$dir/luau.d" -NewName "libluau.d" -Force }
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/native/luau-ffi/build.rs
+++ b/native/luau-ffi/build.rs
@@ -36,7 +36,7 @@ fn main() {
     if target == "aarch64-unknown-linux-gnu" {
         println!("cargo:rustc-link-search=native={}/build", dst.display());
         println!("cargo:rustc-link-lib=dylib=stdc++");
-    } else if target == "x86_64-pc-windows-msvc" {
+    } else if target == "x86_64-pc-windows-msvc" || target == "aarch64-pc-windows-msvc" {
         println!(
             "cargo:rustc-link-search=native={}/build/Release",
             dst.display()
@@ -147,7 +147,7 @@ fn new_cmake_config() -> cmake::Config {
 
     let target = build_target::target_triple().unwrap();
 
-    if target == "x86_64-pc-windows-msvc" {
+    if target == "x86_64-pc-windows-msvc" || target == "aarch64-pc-windows-msvc" {
         if let Ok(cc) = std::env::var("CC") {
             if !cc.is_empty() {
                 config.define("CMAKE_C_COMPILER", cc);

--- a/src/Luau.Native/Luau.Native.csproj
+++ b/src/Luau.Native/Luau.Native.csproj
@@ -22,6 +22,8 @@
       PackagePath="runtimes\osx-arm64\native\" CopyToOutputDirectory="Always" />
     <None Include="runtimes\osx-x64\native\libluau.dylib" Pack="true"
       PackagePath="runtimes\osx-x64\native\" CopyToOutputDirectory="Always" />
+    <None Include="runtimes\win-arm64\native\libluau.dll" Pack="true"
+      PackagePath="runtimes\win-arm64\native\" CopyToOutputDirectory="Always" />
     <None Include="runtimes\win-x64\native\libluau.dll" Pack="true"
       PackagePath="runtimes\win-x64\native\" CopyToOutputDirectory="Always" />
   </ItemGroup>


### PR DESCRIPTION
This pull request is intended to add Windows arm64 support, by changing from MINGW to MSVC, and running the ARM64 build on `windows-11-arm`.

I have tested the workflow and it appears to run correctly :)

Although, some of the other workflows seem to error for me, but that was the case before this pull request.