### PR TITLE
Fix stack leak in LuauTable.cs

### DIFF
--- a/src/Luau/LuauTable.cs
+++ b/src/Luau/LuauTable.cs
@@ -44,6 +44,7 @@ public unsafe sealed class LuauTable : ILuauReference, IDisposable, IEnumerable<
             state.Push(key);
             lua_gettable(state.AsPointer(), -2);
             var result = state.Pop();
+            lua_pop(state.AsPointer(), 1);
             return result;
         }
         set


### PR DESCRIPTION
Fixed a stack memory leak in LuauTable.cs caused by not removing the table from the stack after table indexing.